### PR TITLE
Make --config and --debug shared across all subcommands

### DIFF
--- a/sys_util.py
+++ b/sys_util.py
@@ -16,28 +16,34 @@ DEFAULT_CONFIG_PATH = "~/.config/confgit.yml"
 
 
 def get_arguments():
-    parser = argparse.ArgumentParser(
-        prog="confgit",
-        description="Git overhead for version control of your config files",
-        formatter_class=argparse.RawTextHelpFormatter, )
+    common = argparse.ArgumentParser(
+        add_help=False,
+    )
 
-    parser.add_argument(
+    common.add_argument(
         "-c", "--config",
         type=str,
         default=DEFAULT_CONFIG_PATH,
         dest="CONFIG_PATH",
         help="load alternative config")
 
-    parser.add_argument(
+    common.add_argument(
         "--debug",
         action="store_true",
         default=False,
         dest="debug",
         help="enable debug mode")
 
+    parser = argparse.ArgumentParser(
+        prog="confgit",
+        description="Git overhead for version control of your config files",
+        formatter_class=argparse.RawTextHelpFormatter,
+        parents=[common],)
+
+
     subparsers = parser.add_subparsers(help="Confgit commands:")
 
-    subparsers.add_parser("init", help="Init confgit repository").add_argument(
+    subparsers.add_parser("init", help="Init confgit repository", parents=[common]).add_argument(
         "init_path",
         type=str,
         action="store",
@@ -45,22 +51,22 @@ def get_arguments():
         metavar="test_init",
         default=str(getcwd()) + "/",
         help="path of directory where you want to init confgit repository")
-    subparsers.add_parser("sync", help="Sync origins of files from confgit repository").add_argument(
+    subparsers.add_parser("sync", help="Sync origins of files from confgit repository", parents=[common]).add_argument(
         "sync",
         action="store_true",
         help="update original config files from their git copies")
-    subparsers.add_parser("update", help="Update files in config repository from their origin").add_argument(
+    subparsers.add_parser("update", help="Update files in config repository from their origin", parents=[common]).add_argument(
         "update",
         action="store_true",
         help="")
-    subparsers.add_parser("backup", help="Create zip file with backup of all files in confgit repository").add_argument(
+    subparsers.add_parser("backup", help="Create zip file with backup of all files in confgit repository", parents=[common]).add_argument(
         "backup_name",
         type=str,
         action="store",
         nargs="?",
         default=f"confgit-backup-{str(datetime.datetime.now()).replace(' ', '-')}.zip",
         help="create zip file with config backup")
-    subparsers.add_parser("include", help="Include file or directory in to confgit repository").add_argument(
+    subparsers.add_parser("include", help="Include file or directory in to confgit repository", parents=[common]).add_argument(
         "file_to_include",
         type=str,
         action="store",
@@ -68,7 +74,7 @@ def get_arguments():
         const="",
         default=False,
         help="include file or directory in to confgit repository")
-    subparsers.add_parser("exclude", help="Exclude file or directory in to confgit repository").add_argument(
+    subparsers.add_parser("exclude", help="Exclude file or directory in to confgit repository", parents=[common]).add_argument(
         "file_to_exclude",
         type=str,
         action="store",


### PR DESCRIPTION
Both `confgit -c /config init` and `confgit init -c /config` are therefore valid.

Part of #15
Resolves #10